### PR TITLE
Fix issue #77 to use Pascal case for all Json properties

### DIFF
--- a/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeviceTwinServiceModel.java
+++ b/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/DeviceTwinServiceModel.java
@@ -2,6 +2,7 @@
 
 package com.microsoft.azure.iotsolutions.iothubmanager.services.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.helpers.HashMapHelper;
 import com.microsoft.azure.sdk.iot.service.devicetwin.DeviceTwinDevice;
 
@@ -44,10 +45,12 @@ public final class DeviceTwinServiceModel {
         );
     }
 
-    public String getEtag() {
+    @JsonProperty("ETag")
+    public String getETag() {
         return this.eTag;
     }
 
+    @JsonProperty("DeviceId")
     public String getDeviceId() {
         return this.deviceId;
     }
@@ -56,14 +59,17 @@ public final class DeviceTwinServiceModel {
         this.deviceId = deviceId;
     }
 
+    @JsonProperty("Properties")
     public DeviceTwinProperties getProperties() {
         return this.properties;
     }
 
+    @JsonProperty("Tags")
     public HashMap getTags() {
         return this.tags;
     }
 
+    @JsonProperty("IsSimulated")
     public Boolean getIsSimulated() {
         return isSimulated;
     }
@@ -77,8 +83,8 @@ public final class DeviceTwinServiceModel {
         DeviceTwinDevice twinDevice = this.getDeviceId() == null || this.getDeviceId().isEmpty()
             ? new DeviceTwinDevice() : new DeviceTwinDevice(this.getDeviceId());
 
-        if (this.getEtag() != null) {
-            twinDevice.setETag(this.getEtag());
+        if (this.getETag() != null) {
+            twinDevice.setETag(this.getETag());
         }
 
         if (this.getTags() != null) {

--- a/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/JobStatistics.java
+++ b/app/com/microsoft/azure/iotsolutions/iothubmanager/services/models/JobStatistics.java
@@ -2,6 +2,8 @@
 
 package com.microsoft.azure.iotsolutions.iothubmanager.services.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class JobStatistics {
 
     private int deviceCount;
@@ -22,6 +24,7 @@ public class JobStatistics {
         }
     }
 
+    @JsonProperty("DeviceCount")
     public int getDeviceCount() {
         return deviceCount;
     }
@@ -30,6 +33,7 @@ public class JobStatistics {
         this.deviceCount = deviceCount;
     }
 
+    @JsonProperty("FailedCount")
     public int getFailedCount() {
         return failedCount;
     }
@@ -38,6 +42,7 @@ public class JobStatistics {
         this.failedCount = failedCount;
     }
 
+    @JsonProperty("SucceededCount")
     public int getSucceededCount() {
         return succeededCount;
     }
@@ -46,6 +51,7 @@ public class JobStatistics {
         this.succeededCount = succeededCount;
     }
 
+    @JsonProperty("RunningCount")
     public int getRunningCount() {
         return runningCount;
     }
@@ -54,6 +60,7 @@ public class JobStatistics {
         this.runningCount = runningCount;
     }
 
+    @JsonProperty("PendingCount")
     public int getPendingCount() {
         return pendingCount;
     }

--- a/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeviceListApiModel.java
+++ b/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeviceListApiModel.java
@@ -30,7 +30,7 @@ public final class DeviceListApiModel {
         }
     }
 
-    @JsonProperty("items")
+    @JsonProperty("Items")
     public List<DeviceRegistryApiModel> getItems() {
         return items;
     }
@@ -43,7 +43,7 @@ public final class DeviceListApiModel {
         }};
     }
 
-    @JsonProperty("continuationToken")
+    @JsonProperty("ContinuationToken")
     public String getContinuationToken() {
         return continuationToken;
     }

--- a/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeviceRegistryApiModel.java
+++ b/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/DeviceRegistryApiModel.java
@@ -53,7 +53,7 @@ public final class DeviceRegistryApiModel {
 
         DeviceTwinServiceModel twinModel = device.getTwin();
         if (twinModel != null) {
-            this.eTag = this.eTag + "|" + device.getTwin().getEtag();
+            this.eTag = this.eTag + "|" + device.getTwin().getETag();
             this.properties = twinModel.getProperties();
             this.tags = device.getTwin().getTags();
             this.isSimulated = device.getTwin().getIsSimulated();

--- a/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/JobApiModel.java
+++ b/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/JobApiModel.java
@@ -71,112 +71,103 @@ public class JobApiModel {
         return serviceModel;
     }
 
-    @JsonProperty("jobId")
+    @JsonProperty("JobId")
     public String getJobId() {
         return jobId;
     }
 
-    @JsonProperty("JobId")
     public void setJobId(String jobId) {
         this.jobId = jobId;
     }
 
-    @JsonProperty("queryCondition")
+    @JsonProperty("QueryCondition")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getQueryCondition() {
         return queryCondition;
     }
 
-    @JsonProperty("QueryCondition")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setQueryCondition(String queryCondition) {
         this.queryCondition = queryCondition;
     }
 
-    @JsonProperty("createdTimeUtc")
+    @JsonProperty("CreatedTimeUtc")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = dateFormatString)
     public Date getCreatedTimeUtc() {
         return createdTimeUtc;
     }
 
-    @JsonProperty("CreatedTimeUtc")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setCreatedTimeUtc(Date createdTimeUtc) {
         this.createdTimeUtc = createdTimeUtc;
     }
 
-    @JsonProperty("startTimeUtc")
+    @JsonProperty("StartTimeUtc")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = dateFormatString)
     public Date getStartTimeUtc() {
         return startTimeUtc;
     }
 
-    @JsonProperty("StartTimeUtc")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setStartTimeUtc(Date startTimeUtc) {
         this.startTimeUtc = startTimeUtc;
     }
 
-    @JsonProperty("endTimeUtc")
+    @JsonProperty("EndTimeUtc")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = dateFormatString)
     public Date getEndTimeUtc() {
         return endTimeUtc;
     }
 
-    @JsonProperty("EndTimeUtc")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setEndTimeUtc(Date endTimeUtc) {
         this.endTimeUtc = endTimeUtc;
     }
 
-    @JsonProperty("maxExecutionTimeInSeconds")
+    @JsonProperty("MaxExecutionTimeInSeconds")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Long getMaxExecutionTimeInSeconds() {
         return maxExecutionTimeInSeconds;
     }
 
-    @JsonProperty("MaxExecutionTimeInSeconds")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setMaxExecutionTimeInSeconds(Long maxExecutionTimeInSeconds) {
         this.maxExecutionTimeInSeconds = maxExecutionTimeInSeconds;
     }
 
-    @JsonProperty("type")
+    @JsonProperty("Type")
     public JobType getType() {
         return type;
     }
 
-    @JsonProperty("Type")
     public void setType(JobType type) {
         this.type = type;
     }
 
-    @JsonProperty("status")
+    @JsonProperty("Status")
     public JobStatus getStatus() {
         return status;
     }
 
-    @JsonProperty("Status")
     public void setStatus(JobStatus status) {
         this.status = status;
     }
 
-    @JsonProperty("methodParameter")
+    @JsonProperty("MethodParameter")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public MethodParameterApiModel getMethodParameter() {
         return methodParameter;
     }
 
-    @JsonProperty("MethodParameter")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setMethodParameter(MethodParameterApiModel methodParameter) {
         this.methodParameter = methodParameter;
     }
 
-    @JsonProperty("updateTwin")
+    @JsonProperty("UpdateTwin")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public DeviceTwinServiceModel getUpdateTwin() {
         return updateTwin;
@@ -187,7 +178,7 @@ public class JobApiModel {
         this.updateTwin = updateTwin;
     }
 
-    @JsonProperty("failureReason")
+    @JsonProperty("FailureReason")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getFailureReason() {
         return failureReason;
@@ -197,7 +188,7 @@ public class JobApiModel {
         this.failureReason = failureReason;
     }
 
-    @JsonProperty("statusMessage")
+    @JsonProperty("StatusMessage")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getStatusMessage() {
         return statusMessage;
@@ -207,7 +198,7 @@ public class JobApiModel {
         this.statusMessage = statusMessage;
     }
 
-    @JsonProperty("resultStatistics")
+    @JsonProperty("ResultStatistics")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public JobStatistics getResultStatistics() {
         return resultStatistics;

--- a/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/MethodParameterApiModel.java
+++ b/app/com/microsoft/azure/iotsolutions/iothubmanager/webservice/v1/models/MethodParameterApiModel.java
@@ -2,8 +2,7 @@
 
 package com.microsoft.azure.iotsolutions.iothubmanager.webservice.v1.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.microsoft.azure.iotsolutions.iothubmanager.services.models.MethodParameterServiceModel;
 
 import java.time.Duration;
@@ -27,17 +26,17 @@ public class MethodParameterApiModel {
         }
     }
 
-    @JsonProperty("name")
+    @JsonProperty("Name")
     public String getName() {
         return name;
     }
 
-    @JsonProperty("Name")
     public void setName(String value) {
         this.name = value;
     }
 
-    @JsonProperty("responseTimeout")
+    @JsonProperty("ResponseTimeout")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Duration getResponseTimeout() {
         return this.responseTimeout;
     }
@@ -46,7 +45,8 @@ public class MethodParameterApiModel {
         this.responseTimeout = value;
     }
 
-    @JsonProperty("connectionTimeout")
+    @JsonProperty("ConnectionTimeout")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Duration getConnectionTimeout() {
         return this.connectionTimeout;
     }
@@ -55,7 +55,7 @@ public class MethodParameterApiModel {
         this.connectionTimeout = value;
     }
 
-    @JsonProperty("jsonPayload")
+    @JsonProperty("JsonPayload")
     public String getJsonPayload() {
         return this.jsonPayload;
     }


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

This work will eliminate inconsistency of Json property naming and use Pascal Case if applicable (except $metadata). 

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [x] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
