### PR TITLE
Bump Azure IoT SDK to new release 2017-12-2

### DIFF
--- a/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Devices.java
+++ b/app/com/microsoft/azure/iotsolutions/iothubmanager/services/Devices.java
@@ -261,13 +261,6 @@ public final class Devices implements IDevices {
             }
         } catch (IotHubException | IOException e) {
             throw new ExternalDependencyException("Unable to query device twin", e);
-        } catch (IllegalArgumentException e) {
-            // Java SDK will throw IllegalArgumentException when the query result is empty:
-            // "java.lang.IllegalArgumentException: Provided Collection must not be null and cannot be empty"
-            // This is workaround to capture this exception and ignore it.
-            // bug filed for Java SDK: https://github.com/Azure/azure-iot-sdk-java/issues/176
-            String message = String.format("Ignored IllegalArgumentException when twin query return empty result: %s", query);
-            log.warn(message, e);
         }
 
         return twins;

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= {
     ws,
 
     // https://github.com/Azure/azure-iot-sdk-java/releases
-    "com.microsoft.azure.sdk.iot" % "iot-service-client" % "1.10.28",
+    "com.microsoft.azure.sdk.iot" % "iot-service-client" % "1.11.0",
 
     // https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk
     "com.nimbusds" % "oauth2-oidc-sdk" % "5.36"
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   // http://search.maven.org/#search%7Cga%7C1%7Cmockito-core
   "org.mockito" % "mockito-core" % "2.8.47" % "test",
   // https://github.com/Azure/azure-iot-sdk-java/releases
-  "com.microsoft.azure.sdk.iot" % "iot-device-client" % "1.5.37" % "test"
+  "com.microsoft.azure.sdk.iot" % "iot-device-client" % "1.6.0" % "test"
 )
 
 lazy val commonSettings = Seq(


### PR DESCRIPTION
* Bump Java IotHub Device Client to 1.6.0
* Bump Java IotHub Service Client to 1.11.0
* Remove workaround code to catch IllegalArgumentException when twin query result is empty

# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

...

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
