### PR TITLE
Fix issue #85 Remove prefix of Tags and Reported for device group fil…

### DIFF
--- a/app/com/microsoft/azure/iotsolutions/iothubmanager/services/external/ConfigService.java
+++ b/app/com/microsoft/azure/iotsolutions/iothubmanager/services/external/ConfigService.java
@@ -31,12 +31,12 @@ public class ConfigService implements IConfigService {
         DeviceGroupFiltersApiModel model = new DeviceGroupFiltersApiModel();
 
         if (twin.getTags() != null) {
-            model.setTags(HashMapHelper.mapToHashSet("Tags", twin.getTags()));
+            model.setTags(HashMapHelper.mapToHashSet("", twin.getTags()));
         }
 
         DeviceTwinProperties properties = twin.getProperties();
         if (properties != null && properties.getReported() != null) {
-            model.setReported(HashMapHelper.mapToHashSet("Reported", properties.getReported()));
+            model.setReported(HashMapHelper.mapToHashSet("", properties.getReported()));
         }
 
         String url = this.serviceUrl + "/devicegroupfilters";

--- a/app/com/microsoft/azure/iotsolutions/iothubmanager/services/helpers/HashMapHelper.java
+++ b/app/com/microsoft/azure/iotsolutions/iothubmanager/services/helpers/HashMapHelper.java
@@ -46,6 +46,7 @@ public class HashMapHelper {
      * @param map    the map to be converted such as HashMap, LinkedTreeMap.
      */
     public static HashSet<String> mapToHashSet(String prefix, Map<String, Object> map) {
+        String dottedPrefix = prefix == null || prefix.isEmpty() ? "" : prefix + ".";
         HashSet<String> set = new HashSet<>();
         if (map != null) {
             for (Map.Entry<String, Object> setEntry : map.entrySet()) {
@@ -53,9 +54,9 @@ public class HashMapHelper {
                 if (value instanceof String
                     || value instanceof Boolean
                     || value instanceof Number) {
-                    set.add(prefix + "." + setEntry.getKey());
+                    set.add(dottedPrefix + setEntry.getKey());
                 } else if (value instanceof Map) {
-                    set.addAll(mapToHashSet(prefix + "." + setEntry.getKey(), (Map) setEntry.getValue()));
+                    set.addAll(mapToHashSet(dottedPrefix + setEntry.getKey(), (Map) setEntry.getValue()));
                 }
             }
         }

--- a/test/com/microsoft/azure/iotsolutions/iothubmanager/services/helpers/HashMapHelperTest.java
+++ b/test/com/microsoft/azure/iotsolutions/iothubmanager/services/helpers/HashMapHelperTest.java
@@ -57,7 +57,7 @@ public class HashMapHelperTest {
 
     @Test(timeout = 1000)
     @Category({UnitTest.class})
-    public void MapToHasSetTest() {
+    public void MapToHashSetTest() {
         Assert.assertTrue(HashMapHelper.mapToHashSet("", null).size() == 0);
 
         LinkedTreeMap linkedTreeMap = new LinkedTreeMap();
@@ -93,5 +93,18 @@ public class HashMapHelperTest {
         );
         Assert.assertTrue(set.containsAll(expectedList));
         Assert.assertTrue(expectedList.containsAll(set));
+
+        HashSet<String> setWithoutPrefix = HashMapHelper.mapToHashSet("", table);
+
+        List<String> expectedListWithoutPrefix = Arrays.asList(
+                "aString",
+                "aBool",
+                "aNumber",
+                "map1Level1.aString",
+                "map2Level1.map2Level2-1.aString",
+                "map2Level1.map2Level2-2.mapLevel3"
+        );
+        Assert.assertTrue(setWithoutPrefix.containsAll(expectedListWithoutPrefix));
+        Assert.assertTrue(expectedListWithoutPrefix.containsAll(setWithoutPrefix));
     }
 }


### PR DESCRIPTION
…ters

Since the device group filter define tags and reported property, the
'Tags' and 'Reported" prefix is not needed.

# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

...

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
